### PR TITLE
Remove max supply | resolves #6

### DIFF
--- a/contracts/MarketCapSqrtController.sol
+++ b/contracts/MarketCapSqrtController.sol
@@ -333,26 +333,6 @@ contract MarketCapSqrtController is MarketCapSortedTokenCategories {
   }
 
   /**
-   * @dev Sets the maximum number of pool tokens that can be minted
-   * for a particular pool.
-   *
-   * This value will be used in the alpha to limit the maximum damage
-   * that can be caused by a catastrophic error. It can be gradually
-   * increased as the pool continues to not be exploited.
-   *
-   * If it is set to 0, the limit will be removed.
-   *
-   * @param poolAddress Address of the pool to set the limit on.
-   * @param maxPoolTokens Maximum LP tokens the pool can mint.
-   */
-  function setMaxPoolTokens(
-    address poolAddress,
-    uint256 maxPoolTokens
-  ) external onlyOwner _havePool(poolAddress) {
-    IIndexPool(poolAddress).setMaxPoolTokens(maxPoolTokens);
-  }
-
-  /**
    * @dev Sets the swap fee on an index pool.
    */
   function setSwapFee(address poolAddress, uint256 swapFee) external onlyOwner _havePool(poolAddress) {

--- a/contracts/interfaces/IIndexPool.sol
+++ b/contracts/interfaces/IIndexPool.sol
@@ -80,8 +80,6 @@ interface IIndexPool {
     address unbindHandler
   ) external;
 
-  function setMaxPoolTokens(uint256 maxPoolTokens) external;
-
   function setSwapFee(uint256 swapFee) external;
 
   function delegateCompLikeToken(address token, address delegatee) external;
@@ -158,8 +156,6 @@ interface IIndexPool {
   function getSwapFee() external view returns (uint256/* swapFee */);
 
   function getController() external view returns (address);
-
-  function getMaxPoolTokens() external view returns (uint256);
 
   function isBound(address t) external view returns (bool);
 

--- a/test/IPool/IPool.spec.js
+++ b/test/IPool/IPool.spec.js
@@ -78,18 +78,12 @@ describe('IndexPool.sol', async () => {
       const controllerAddress = await indexPool.getController();
       expect(controllerAddress).to.eq(from)
     });
-
-    it('getMaxPoolTokens()', async () => {
-      const maxPoolTokens = await indexPool.getMaxPoolTokens();
-      expect(maxPoolTokens.eq(0)).to.be.true;
-    });
   });
 
   describe('Control & Public', async () => {
     it('Functions with _control_ role are only callable by controller', async () => {
       const controllerOnlyFunctions = [
         'initialize',
-        'setMaxPoolTokens',
         'setSwapFee',
         'reweighTokens',
         'reindexTokens',
@@ -768,18 +762,6 @@ describe('IndexPool.sol', async () => {
       await verifyRevert('joinswapExternAmountIn', /ERR_MAX_IN_RATIO/g, tokens[0], balances[0].div(2).add(1e3), zero);
     });
 
-    it('Reverts if totalSupply + pAO > maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens(await indexPool.totalSupply());
-      await verifyRevert('joinswapExternAmountIn', /ERR_MAX_POOL_TOKENS/g, tokens[0], toWei(1), zero);
-      await indexPool.setMaxPoolTokens(0);
-    });
-
-    it('Allows tokens to be minted up to maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens((await indexPool.totalSupply()).add(toWei(1)));
-      await indexPool.callStatic.joinswapExternAmountIn(tokens[0], toWei(1), zero);
-      await indexPool.setMaxPoolTokens(0);
-    });
-
     it('Reverts if poolAmountOut < minPoolAmountOut', async () => {
       const expectedAmountOut = poolHelper.calcPoolOutGivenSingleIn(tokens[0], 1);
       await verifyRevert('joinswapExternAmountIn', /ERR_LIMIT_OUT/g, tokens[0], toWei(1), toWei(expectedAmountOut).mul(2));
@@ -806,18 +788,6 @@ describe('IndexPool.sol', async () => {
     it('Reverts if tokenAmountIn > balanceIn / 2', async () => {
       const poolAmountOut = poolHelper.calcPoolOutGivenSingleIn(tokens[0], fromWei(balances[0]));
       await verifyRevert('joinswapPoolAmountOut', /ERR_MAX_IN_RATIO/g, tokens[0], toWei(poolAmountOut), maxPrice);
-    });
-
-    it('Reverts if totalSupply + pAO > maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens(await indexPool.totalSupply());
-      await verifyRevert('joinswapPoolAmountOut', /ERR_MAX_POOL_TOKENS/g, tokens[0], toWei(1), zero);
-      await indexPool.setMaxPoolTokens(0);
-    });
-
-    it('Allows tokens to be minted up to maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens((await indexPool.totalSupply()).add(toWei(1)));
-      await indexPool.callStatic.joinswapPoolAmountOut(tokens[0], toWei(1), maxPrice);
-      await indexPool.setMaxPoolTokens(0);
     });
 
     it('Reverts if tokenAmountIn > maxAmountIn', async () => {
@@ -854,18 +824,6 @@ describe('IndexPool.sol', async () => {
 
     it('Reverts if tokenAmountIn > maxAmountIn', async () => {
       await verifyRevert('joinPool', /ERR_LIMIT_IN/g, toWei(1), [maxPrice, 0, maxPrice]);
-    });
-
-    it('Reverts if totalSupply + pAO > maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens(await indexPool.totalSupply());
-      await verifyRevert('joinPool', /ERR_MAX_POOL_TOKENS/g, toWei(1), [maxPrice, maxPrice, maxPrice]);
-      await indexPool.setMaxPoolTokens(0);
-    });
-
-    it('Allows tokens to be minted up to maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens((await indexPool.totalSupply()).add(toWei(1)));
-      await indexPool.callStatic.joinPool(toWei(1), [maxPrice, maxPrice, maxPrice]);
-      await indexPool.setMaxPoolTokens(0);
     });
 
     it('Prices initialized tokens normally', async () => {

--- a/test/IPool/Maximum.spec.js
+++ b/test/IPool/Maximum.spec.js
@@ -87,18 +87,12 @@ describe('IndexPool.sol', async () => {
       const controllerAddress = await indexPool.getController();
       expect(controllerAddress).to.eq(from)
     });
-
-    it('getMaxPoolTokens()', async () => {
-      const maxPoolTokens = await indexPool.getMaxPoolTokens();
-      expect(maxPoolTokens.eq(0)).to.be.true;
-    });
   });
 
   describe('Control & Public', async () => {
     it('Functions with _control_ role are only callable by controller', async () => {
       const controllerOnlyFunctions = [
         'initialize',
-        'setMaxPoolTokens',
         'setSwapFee',
         'reweighTokens',
         'reindexTokens',
@@ -788,18 +782,6 @@ describe('IndexPool.sol', async () => {
       await verifyRevert('joinswapExternAmountIn', /ERR_MAX_IN_RATIO/g, tokens[0], balances[0].div(2).add(1e3), zero);
     });
 
-    it('Reverts if totalSupply + pAO > maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens(await indexPool.totalSupply());
-      await verifyRevert('joinswapExternAmountIn', /ERR_MAX_POOL_TOKENS/g, tokens[0], toWei(1), zero);
-      await indexPool.setMaxPoolTokens(0);
-    });
-
-    it('Allows tokens to be minted up to maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens((await indexPool.totalSupply()).add(toWei(1)));
-      await indexPool.callStatic.joinswapExternAmountIn(tokens[0], toWei(1), zero);
-      await indexPool.setMaxPoolTokens(0);
-    });
-
     it('Reverts if poolAmountOut < minPoolAmountOut', async () => {
       const expectedAmountOut = poolHelper.calcPoolOutGivenSingleIn(tokens[0], 1);
       await verifyRevert('joinswapExternAmountIn', /ERR_LIMIT_OUT/g, tokens[0], toWei(1), toWei(expectedAmountOut).mul(2));
@@ -828,18 +810,6 @@ describe('IndexPool.sol', async () => {
     it('Reverts if tokenAmountIn > balanceIn / 2', async () => {
       const poolAmountOut = poolHelper.calcPoolOutGivenSingleIn(tokens[0], fromWei(balances[0]));
       await verifyRevert('joinswapPoolAmountOut', /ERR_MAX_IN_RATIO/g, tokens[0], toWei(poolAmountOut), maxPrice);
-    });
-
-    it('Reverts if totalSupply + pAO > maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens(await indexPool.totalSupply());
-      await verifyRevert('joinswapPoolAmountOut', /ERR_MAX_POOL_TOKENS/g, tokens[0], toWei(1), zero);
-      await indexPool.setMaxPoolTokens(0);
-    });
-
-    it('Allows tokens to be minted up to maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens((await indexPool.totalSupply()).add(toWei(1)));
-      await indexPool.callStatic.joinswapPoolAmountOut(tokens[0], toWei(1), maxPrice);
-      await indexPool.setMaxPoolTokens(0);
     });
 
     it('Reverts if tokenAmountIn > maxAmountIn', async () => {
@@ -878,18 +848,6 @@ describe('IndexPool.sol', async () => {
       const maxPrices = new Array(tokens.length).fill(maxPrice);
       maxPrices[0] = 0;
       await verifyRevert('joinPool', /ERR_LIMIT_IN/g, toWei(1), maxPrices);
-    });
-
-    it('Reverts if totalSupply + pAO > maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens(await indexPool.totalSupply());
-      await verifyRevert('joinPool', /ERR_MAX_POOL_TOKENS/g, toWei(1), new Array(tokens.length).fill(maxPrice));
-      await indexPool.setMaxPoolTokens(0);
-    });
-
-    it('Allows tokens to be minted up to maxPoolTokens', async () => {
-      await indexPool.setMaxPoolTokens((await indexPool.totalSupply()).add(toWei(1)));
-      await indexPool.callStatic.joinPool(toWei(1), new Array(tokens.length).fill(maxPrice));
-      await indexPool.setMaxPoolTokens(0);
     });
 
     it('Prices initialized tokens normally', async () => {

--- a/test/MarketCapSqrtController.spec.js
+++ b/test/MarketCapSqrtController.spec.js
@@ -186,7 +186,7 @@ describe('MarketCapSqrtController.sol', async () => {
     setupTests();
 
     it('All functions with onlyOwner modifier revert if caller is not owner', async () => {
-      const onlyOwnerFns = ['prepareIndexPool', 'setDefaultSellerPremium', 'updateSellerPremium', 'setMaxPoolTokens', 'setSwapFee', 'delegateCompLikeTokenFromPool'];
+      const onlyOwnerFns = ['prepareIndexPool', 'setDefaultSellerPremium', 'updateSellerPremium', 'setSwapFee', 'delegateCompLikeTokenFromPool'];
       for (let fn of onlyOwnerFns) {
         await verifyRejection(nonOwnerFaker, fn, /Ownable: caller is not the owner/g);
       }
@@ -198,7 +198,7 @@ describe('MarketCapSqrtController.sol', async () => {
 
     it('All functions with _havePool modifier revert if pool address not recognized', async () => {
       // reweighPool & reindexPool included even though there is no modifier because it uses the same validation
-      const onlyOwnerFns = ['setMaxPoolTokens', 'setSwapFee', 'updateMinimumBalance', 'reweighPool', 'reindexPool'];
+      const onlyOwnerFns = ['setSwapFee', 'updateMinimumBalance', 'reweighPool', 'reindexPool'];
       for (let fn of onlyOwnerFns) {
         await verifyRejection(ownerFaker, fn, /ERR_POOL_NOT_FOUND/g);
       }
@@ -336,17 +336,6 @@ describe('MarketCapSqrtController.sol', async () => {
       await controller.updateSellerPremium(tokenSeller.address, 3);
       const premium = await tokenSeller.getPremiumPercent();
       expect(premium).to.eq(3);
-    });
-  });
-
-  describe('setMaxPoolTokens()', async () => {
-    setupTests({ pool: true, init: true, size: 2, ethValue: 1 });
-
-    it('Sets max pool tokens on the pool', async () => {
-      const max = toWei(1000);
-      await controller.setMaxPoolTokens(pool.address, max);
-      const newMax = await pool.getMaxPoolTokens();
-      expect(newMax.eq(max)).to.be.true;
     });
   });
 


### PR DESCRIPTION
Removed getters and setters for maxPoolTokens in index pool.

Removed checks in mint functions that verify the supply does not exceed the maximum.

Removed tests which involve the getters and setters, or verification that the maximums are not exceeded.