### PR TITLE
Add exit fees | Resolves #1

### DIFF
--- a/buidler.config.js
+++ b/buidler.config.js
@@ -98,6 +98,9 @@ module.exports = {
     deployer: {
       default: 0
     },
+    feeRecipient: {
+      default: 1
+    }
   },
   networks: {
     buidlerevm: {

--- a/contracts/MarketCapSqrtController.sol
+++ b/contracts/MarketCapSqrtController.sol
@@ -292,7 +292,8 @@ contract MarketCapSqrtController is MarketCapSortedTokenCategories {
       balances,
       denormalizedWeights,
       msg.sender,
-      sellerAddress
+      sellerAddress,
+      owner()
     );
 
     IUnboundTokenSeller(sellerAddress).initialize(

--- a/contracts/balancer/BConst.sol
+++ b/contracts/balancer/BConst.sol
@@ -37,7 +37,7 @@ contract BConst {
   // Maximum swap or exit fee.
   uint256 internal constant MAX_FEE = BONE / 10;
   // Actual exit fee.
-  uint256 internal constant EXIT_FEE = 0;
+  uint256 internal constant EXIT_FEE = 5e15;
 
   // Default total of all desired weights. Can differ by up to BONE.
   uint256 internal constant DEFAULT_TOTAL_WEIGHT = BONE * 25;

--- a/contracts/interfaces/IIndexPool.sol
+++ b/contracts/interfaces/IIndexPool.sol
@@ -77,12 +77,15 @@ interface IIndexPool {
     uint256[] calldata balances,
     uint96[] calldata denorms,
     address tokenProvider,
-    address unbindHandler
+    address unbindHandler,
+    address exitFeeRecipient
   ) external;
 
   function setSwapFee(uint256 swapFee) external;
 
   function delegateCompLikeToken(address token, address delegatee) external;
+
+  function setExitFeeRecipient(address) external;
 
   function reweighTokens(
     address[] calldata tokens,
@@ -149,6 +152,8 @@ interface IIndexPool {
   function getSwapFee() external view returns (uint256/* swapFee */);
 
   function getController() external view returns (address);
+
+  function getExitFeeRecipient() external view returns (address);
 
   function isBound(address t) external view returns (bool);
 

--- a/test/IPool/IPool.spec.js
+++ b/test/IPool/IPool.spec.js
@@ -855,7 +855,7 @@ describe('IndexPool.sol', async () => {
       await indexPool.exitPool(toWei(poolAmountIn), [0, 0, 0]);
       const currentPoolBalance = await indexPool.totalSupply();
       const poolSupplyDiff = previousPoolBalance.sub(currentPoolBalance);
-      expect(+calcRelativeDiff(1, fromWei(poolSupplyDiff))).to.be.lte(errorDelta);
+      expect(+calcRelativeDiff(0.995, fromWei(poolSupplyDiff))).to.be.lte(errorDelta);
       for (let i = 0; i < tokens.length; i++) {
         const previousTokenBalance = balances[i];
         const currentTokenBalance = await indexPool.getBalance(tokens[i]);

--- a/test/IPool/Maximum.spec.js
+++ b/test/IPool/Maximum.spec.js
@@ -138,7 +138,7 @@ describe('IndexPool.sol', async () => {
     setupTests();
 
     it('Reverts if the pool is already initialized', async () => {
-      await verifyRevert('initialize', /ERR_INITIALIZED/g, [], [], [], zeroAddress, zeroAddress);
+      await verifyRevert('initialize', /ERR_INITIALIZED/g, [], [], [], zeroAddress, zeroAddress, zeroAddress);
     });
     
     it('Reverts if array lengths do not match', async () => {
@@ -150,9 +150,9 @@ describe('IndexPool.sol', async () => {
         await token.getFreeTokens(from, balances[i]);
         await token.approve(pool.address, balances[i]);
       }
-      await verifyRejection(pool, 'initialize', /ERR_ARR_LEN/g, tokens, [zero, zero], denormalizedWeights, zeroAddress, zeroAddress);
-      await verifyRejection(pool, 'initialize', /ERR_ARR_LEN/g, tokens, balances, [zero, zero], zeroAddress, zeroAddress);
-      await verifyRejection(pool, 'initialize', /ERR_ARR_LEN/g, [zeroAddress, zeroAddress], balances, denormalizedWeights, zeroAddress, zeroAddress);
+      await verifyRejection(pool, 'initialize', /ERR_ARR_LEN/g, tokens, [zero, zero], denormalizedWeights, zeroAddress, zeroAddress, zeroAddress);
+      await verifyRejection(pool, 'initialize', /ERR_ARR_LEN/g, tokens, balances, [zero, zero], zeroAddress, zeroAddress, zeroAddress);
+      await verifyRejection(pool, 'initialize', /ERR_ARR_LEN/g, [zeroAddress, zeroAddress], balances, denormalizedWeights, zeroAddress, zeroAddress, zeroAddress);
     });
 
     it('Reverts if less than 2 tokens are provided', async () => {
@@ -163,6 +163,7 @@ describe('IndexPool.sol', async () => {
         [zeroAddress],
         [zero],
         [zero],
+        zeroAddress,
         zeroAddress,
         zeroAddress
       );
@@ -177,6 +178,7 @@ describe('IndexPool.sol', async () => {
         new Array(11).fill(zero),
         new Array(11).fill(zero),
         zeroAddress,
+        zeroAddress,
         zeroAddress
       );
     });
@@ -184,20 +186,20 @@ describe('IndexPool.sol', async () => {
     it('Reverts if any denorm < MIN_WEIGHT', async () => {
       const _denorms = new Array(tokens.length).fill(toWei(1));
       _denorms[_denorms.length - 1] = zero;
-      await verifyRejection(pool, 'initialize', /ERR_MIN_WEIGHT/g, tokens, balances, _denorms, from, zeroAddress);
+      await verifyRejection(pool, 'initialize', /ERR_MIN_WEIGHT/g, tokens, balances, _denorms, from, zeroAddress, from);
     });
     
     it('Reverts if any denorm > MAX_WEIGHT', async () => {
       // const _denorms = [toWei(12), toWei(12), toWei(100)];
       const _denorms = new Array(tokens.length).fill(toWei(1));
       _denorms[_denorms.length - 1] = toWei(100);
-      await verifyRejection(pool, 'initialize', /ERR_MAX_WEIGHT/g, tokens, balances, _denorms, from, zeroAddress);
+      await verifyRejection(pool, 'initialize', /ERR_MAX_WEIGHT/g, tokens, balances, _denorms, from, zeroAddress, from);
     });
     
     it('Reverts if any balance < MIN_BALANCE', async () => {
       const bals = new Array(tokens.length).fill(toWei(1));
       bals[bals.length - 1] = zero;
-      await verifyRejection(pool, 'initialize', /ERR_MIN_BALANCE/g, tokens, bals, denormalizedWeights, from, zeroAddress);
+      await verifyRejection(pool, 'initialize', /ERR_MIN_BALANCE/g, tokens, bals, denormalizedWeights, from, zeroAddress, from);
     });
 
     it('Reverts if total weight > maximum', async () => {
@@ -206,7 +208,7 @@ describe('IndexPool.sol', async () => {
       const _denorms = new Array(len).fill(dn);
       _denorms[_denorms.length - 1] = dn.mul(2);
       //[toWei(12), toWei(12), toWei(12)];
-      await verifyRejection(pool, 'initialize', /ERR_MAX_TOTAL_WEIGHT/g, tokens, balances, _denorms, from, zeroAddress);
+      await verifyRejection(pool, 'initialize', /ERR_MAX_TOTAL_WEIGHT/g, tokens, balances, _denorms, from, zeroAddress, from);
     });
   });
 
@@ -234,7 +236,8 @@ describe('IndexPool.sol', async () => {
         [toWei(100), toWei(100)],
         [toWei(12.5), toWei(12.5)],
         from,
-        handler.address
+        handler.address,
+        from
       );
     });
   

--- a/test/IPool/Maximum.spec.js
+++ b/test/IPool/Maximum.spec.js
@@ -880,7 +880,7 @@ describe('IndexPool.sol', async () => {
       await indexPool.exitPool(toWei(poolAmountIn), amounts);
       const currentPoolBalance = await indexPool.totalSupply();
       const poolSupplyDiff = previousPoolBalance.sub(currentPoolBalance);
-      expect(+calcRelativeDiff(1, fromWei(poolSupplyDiff))).to.be.lte(errorDelta);
+      expect(+calcRelativeDiff(0.995, fromWei(poolSupplyDiff))).to.be.lte(errorDelta);
       for (let i = 0; i < tokens.length; i++) {
         const previousTokenBalance = balances[i];
         const currentTokenBalance = await indexPool.getBalance(tokens[i]);

--- a/test/IPool/Reweigh.spec.js
+++ b/test/IPool/Reweigh.spec.js
@@ -349,7 +349,8 @@ describe('reweighTokens()', async () => {
         balances,
         denormalizedWeights,
         from,
-        unbindTokenHandler.address
+        unbindTokenHandler.address,
+        from
       );
     });
 

--- a/test/fixtures/pool.fixture.js
+++ b/test/fixtures/pool.fixture.js
@@ -7,7 +7,7 @@ const { uniswapFixture } = require('./uniswap.fixture');
 const swapFee = 0.025;
 
 const poolFixture = async ({ getNamedAccounts, ethers, tokens: _wrappedTokens }) => {
-  const { deployer } = await getNamedAccounts();
+  const { deployer, feeRecipient } = await getNamedAccounts();
 
   // Deploy contracts
   const IPoolFactory = await ethers.getContractFactory("IndexPool");
@@ -47,7 +47,8 @@ const poolFixture = async ({ getNamedAccounts, ethers, tokens: _wrappedTokens })
     balances,
     denormWeights,
     deployer,
-    unbindTokenHandler.address
+    unbindTokenHandler.address,
+    feeRecipient
   ));
 
   async function getPoolData() {
@@ -102,7 +103,8 @@ const poolFixture = async ({ getNamedAccounts, ethers, tokens: _wrappedTokens })
     verifyRevert,
     callAndSend,
     faker,
-    nonOwnerFaker
+    nonOwnerFaker,
+    feeRecipient
   };
 };
 

--- a/test/lib/calc_comparisons.js
+++ b/test/lib/calc_comparisons.js
@@ -1,5 +1,7 @@
 const Decimal = require('decimal.js');
 
+const EXIT_FEE = 0.005;
+
 function calcRelativeDiff(expected, actual) {
   return ((Decimal(expected).minus(Decimal(actual))).div(expected)).abs();
 }
@@ -85,7 +87,8 @@ function calcSingleOutGivenPoolIn(
   swapFee
 ) {
   const normalizedWeight = Decimal(tokenWeightOut).div(Decimal(totalWeight));
-  const newPoolSupply = Decimal(poolSupply).minus(Decimal(poolAmountIn));
+  const poolAmountInAfterExitFee = Decimal(poolAmountIn).times(Decimal(1).minus(EXIT_FEE))
+  const newPoolSupply = Decimal(poolSupply).minus(poolAmountInAfterExitFee);
   const poolRatio = newPoolSupply.div(Decimal(poolSupply));
   const boo = Decimal(1).div(normalizedWeight);
   const tokenOutRatio = poolRatio.pow(boo);
@@ -113,9 +116,8 @@ function calcPoolInGivenSingleOut(
   const poolRatio = tokenOutRatio.pow(normalizedWeight);
   const newPoolSupply = poolRatio.mul(Decimal(poolSupply));
   const poolAmountInAfterExitFee = Decimal(poolSupply).minus(newPoolSupply);
-  const poolAmountIn = poolAmountInAfterExitFee.div(Decimal(1));
+  const poolAmountIn = poolAmountInAfterExitFee.div(Decimal(1).minus(EXIT_FEE));
   return poolAmountIn;
-
 }
 
 module.exports = {


### PR DESCRIPTION
## BConst.sol

Set exit fee to 0.5%

## IndexPool.sol

Added `_exitFeeRecipient` address which all exit fees from token burns go to.

Added parameter to `initialize()` to set the initial recipient.

Added getter and setter fns `getExitFeeRecipient` and `setExitFeeRecipient`, the latter only callable by the current recipient.

## MarketCapSqrtController.sol

Provide the controller's owner address as the exit fee recipient in the call to `initialize` on an index pool.

## test/

Added tests for exit fees to the test files in test/IPool/

Updated the pool test fixture to set the exit fee recipient.

## buidler.config.js

Added a named `feeRecipient` account.

