### PR TITLE
Make swaps pausable | Resolves #4

### DIFF
--- a/contracts/balancer/IndexPool.sol
+++ b/contracts/balancer/IndexPool.sol
@@ -571,7 +571,6 @@ contract IndexPool is BToken, BMath, IIndexPool {
     external
     override
     _lock_
-    _public_
     returns (uint256/* tokenAmountOut */)
   {
     Record memory outRecord = _getOutputToken(tokenOut);
@@ -626,7 +625,6 @@ contract IndexPool is BToken, BMath, IIndexPool {
     external
     override
     _lock_
-    _public_
     returns (uint256/* poolAmountIn */)
   {
     Record memory outRecord = _getOutputToken(tokenOut);

--- a/contracts/interfaces/IIndexPool.sol
+++ b/contracts/interfaces/IIndexPool.sol
@@ -60,7 +60,7 @@ interface IIndexPool {
 
   event LOG_TOKEN_READY(address indexed token);
 
-  event LOG_PUBLIC_SWAP_ENABLED();
+  event LOG_PUBLIC_SWAP_TOGGLED(bool enabled);
 
   event LOG_MAX_TOKENS_UPDATED(uint256 maxPoolTokens);
 
@@ -86,6 +86,8 @@ interface IIndexPool {
   function delegateCompLikeToken(address token, address delegatee) external;
 
   function setExitFeeRecipient(address) external;
+
+  function setPublicSwap(bool enabled) external;
 
   function reweighTokens(
     address[] calldata tokens,

--- a/test/IPool/IPool.spec.js
+++ b/test/IPool/IPool.spec.js
@@ -108,6 +108,7 @@ describe('IndexPool.sol', async () => {
         'reweighTokens',
         'reindexTokens',
         'setMinimumBalance',
+        'setPublicSwap'
       ];
       for (let fn of controllerOnlyFunctions) {
         await verifyRejection(nonOwnerFaker, fn, /ERR_NOT_CONTROLLER/g);
@@ -123,7 +124,9 @@ describe('IndexPool.sol', async () => {
         'joinswapExternAmountIn',
         'joinswapPoolAmountOut',
         'swapExactAmountIn',
-        'swapExactAmountOut'
+        'swapExactAmountOut',
+        'exitswapPoolAmountIn',
+        'exitswapExternAmountOut'
       ];
       for (let fn of controllerOnlyFunctions) {
         await verifyRejection(faker, fn, /ERR_NOT_PUBLIC/g);
@@ -313,6 +316,36 @@ describe('IndexPool.sol', async () => {
       expect(retFee.eq(fee)).to.be.true;
     });
   });
+
+  describe('setPublicSwap()', async () => {
+    setupTests();
+
+    it('Freezes public swaps', async () => {
+      await indexPool.setPublicSwap(false);
+      expect(await indexPool.isPublicSwap()).to.be.false;
+    })
+
+    it('Disables functions with _public', async () => {
+      const faker = getFakerContract(indexPool);
+      const controllerOnlyFunctions = [
+        'joinPool',
+        'joinswapExternAmountIn',
+        'joinswapPoolAmountOut',
+        'swapExactAmountIn',
+        'swapExactAmountOut',
+        'exitswapPoolAmountIn',
+        'exitswapExternAmountOut'
+      ];
+      for (let fn of controllerOnlyFunctions) {
+        await verifyRejection(faker, fn, /ERR_NOT_PUBLIC/g);
+      }
+    })
+
+    it('Enables public swaps', async () => {
+      await indexPool.setPublicSwap(true);
+      expect(await indexPool.isPublicSwap()).to.be.true;
+    })
+  })
 
   describe('setMinimumBalance()', async () => {
     setupTests();

--- a/test/IPool/IPool.spec.js
+++ b/test/IPool/IPool.spec.js
@@ -124,9 +124,7 @@ describe('IndexPool.sol', async () => {
         'joinswapExternAmountIn',
         'joinswapPoolAmountOut',
         'swapExactAmountIn',
-        'swapExactAmountOut',
-        'exitswapPoolAmountIn',
-        'exitswapExternAmountOut'
+        'swapExactAmountOut'
       ];
       for (let fn of controllerOnlyFunctions) {
         await verifyRejection(faker, fn, /ERR_NOT_PUBLIC/g);
@@ -332,9 +330,7 @@ describe('IndexPool.sol', async () => {
         'joinswapExternAmountIn',
         'joinswapPoolAmountOut',
         'swapExactAmountIn',
-        'swapExactAmountOut',
-        'exitswapPoolAmountIn',
-        'exitswapExternAmountOut'
+        'swapExactAmountOut'
       ];
       for (let fn of controllerOnlyFunctions) {
         await verifyRejection(faker, fn, /ERR_NOT_PUBLIC/g);


### PR DESCRIPTION
# IndexPool.sol

Added `setPublicSwap` function to allow the controller to enable/disable public swaps & single-token joins.

Replaced `LOG_PUBLIC_SWAP_ENABLED` with `LOG_PUBLIC_SWAP_TOGGLED`.

~~Added `_public_` modifier to `exitswapPoolAmountIn` and `exitswapExternAmountOut` to ensure COVER-like vulnerabilities can not be exploited through single-token exits while the pool is frozen.~~ Removed these changes as they are not necessary with joins already blocked.

# test/IPool/IPool.spec.js

Added tests for `setPublicSwap`

~~Added `exitswapPoolAmountIn` and `exitswapExternAmountOut` to tests for `_public_` modifier.~~