### PR TITLE
Moved controller assignment in seller & initializer to initialize fn calls | Resolves #3

### DIFF
--- a/contracts/MarketCapSqrtController.sol
+++ b/contracts/MarketCapSqrtController.sol
@@ -236,7 +236,7 @@ contract MarketCapSqrtController is MarketCapSortedTokenCategories {
       uint256[] memory balances
     ) = getInitialTokensAndBalances(categoryID, indexSize, uint144(initialWethValue));
 
-    initializer.initialize(poolAddress, tokens, balances);
+    initializer.initialize(address(this), poolAddress, tokens, balances);
 
     emit NewPoolInitializer(
       poolAddress,

--- a/contracts/MarketCapSqrtController.sol
+++ b/contracts/MarketCapSqrtController.sol
@@ -297,6 +297,7 @@ contract MarketCapSqrtController is MarketCapSortedTokenCategories {
     );
 
     IUnboundTokenSeller(sellerAddress).initialize(
+      address(this),
       poolAddress,
       defaultSellerPremium
     );

--- a/contracts/PoolInitializer.sol
+++ b/contracts/PoolInitializer.sol
@@ -38,7 +38,6 @@ contract PoolInitializer is IPoolInitializer {
   uint32 internal constant SHORT_TWAP_MAX_TIME_ELAPSED = 2 days;
   uint256 internal constant TOKENS_MINTED = 1e20;
 
-  address public immutable controller;
   IIndexedUniswapV2Oracle public immutable oracle;
 
 /* ==========  Events  ========== */
@@ -58,6 +57,9 @@ contract PoolInitializer is IPoolInitializer {
   // Value contributed in ether
   mapping(address => uint256) internal _credits;
   address[] internal _tokens;
+
+  // Address of the pool controller
+  address public controller;
   // Total value in ether contributed to the pool, computed at the time
   // of receipt.
   uint256 internal _totalCredit;
@@ -75,11 +77,6 @@ contract PoolInitializer is IPoolInitializer {
     _mutex = false;
   }
 
-  modifier _control_ {
-    require(msg.sender == controller, "ERR_NOT_CONTROLLER");
-    _;
-  }
-
   modifier _finished_ {
     require(_finished, "ERR_NOT_FINISHED");
     _;
@@ -92,12 +89,8 @@ contract PoolInitializer is IPoolInitializer {
 
 /* ==========  Constructor  ========== */
 
-  constructor(
-    IIndexedUniswapV2Oracle oracle_,
-    address controller_
-  ) public {
+  constructor(IIndexedUniswapV2Oracle oracle_) public {
     oracle = oracle_;
-    controller = controller_;
   }
 
 /* ==========  Start & Finish Functions  ========== */
@@ -105,21 +98,23 @@ contract PoolInitializer is IPoolInitializer {
   /**
    * @dev Sets up the pre-deployment pool.
    *
+   * @param controller_ Address of the pool controller
    * @param poolAddress Address of the pool this pre-deployment pool is for
    * @param tokens Array of desired tokens
    * @param amounts Desired amounts of the corresponding `tokens`
    */
   function initialize(
+    address controller_,
     address poolAddress,
     address[] calldata tokens,
     uint256[] calldata amounts
   )
     external
     override
-    _control_
   {
     require(_poolAddress == address(0), "ERR_INITIALIZED");
     _poolAddress = poolAddress;
+    controller = controller_;
     uint256 len = tokens.length;
     require(amounts.length == len, "ERR_ARR_LEN");
     _tokens = tokens;

--- a/contracts/UnboundTokenSeller.sol
+++ b/contracts/UnboundTokenSeller.sol
@@ -48,7 +48,6 @@ contract UnboundTokenSeller is IUnboundTokenSeller {
   uint32 internal constant SHORT_TWAP_MAX_TIME_ELAPSED = 2 days;
 
   IUniswapV2Router02 internal immutable _uniswapRouter;
-  address public immutable controller;
   IIndexedUniswapV2Oracle public immutable oracle;
 
 /* ==========  Events  ========== */
@@ -74,6 +73,7 @@ contract UnboundTokenSeller is IUnboundTokenSeller {
   );
 
 /* ==========  Storage  ========== */
+  address public controller;
   // Pool the contract is selling tokens for.
   IIndexPool internal _pool;
   // Premium on the amount paid in swaps.
@@ -106,22 +106,19 @@ contract UnboundTokenSeller is IUnboundTokenSeller {
 
   constructor(
     IUniswapV2Router02 uniswapRouter,
-    IIndexedUniswapV2Oracle oracle_,
-    address controller_
+    IIndexedUniswapV2Oracle oracle_
   ) public {
     _uniswapRouter = uniswapRouter;
     oracle = oracle_;
-    controller = controller_;
   }
 
   /**
    * @dev Initialize the proxy contract with the acceptable premium rate
    * and the address of the pool it is for.
    */
-  function initialize(address pool, uint8 premiumPercent)
+  function initialize(address controller_, address pool, uint8 premiumPercent)
     external
     override
-    _control_
   {
     require(address(_pool) == address(0), "ERR_INITIALIZED");
     require(pool != address(0), "ERR_NULL_ADDRESS");
@@ -131,6 +128,7 @@ contract UnboundTokenSeller is IUnboundTokenSeller {
     );
     _premiumPercent = premiumPercent;
     _pool = IIndexPool(pool);
+    controller = controller_;
   }
 
 /* ==========  Controls  ========== */

--- a/contracts/interfaces/IPoolInitializer.sol
+++ b/contracts/interfaces/IPoolInitializer.sol
@@ -15,6 +15,7 @@ interface IPoolInitializer {
 /* ========== Mutative ========== */
 
   function initialize(
+    address controller,
     address poolAddress,
     address[] calldata tokens,
     uint256[] calldata amounts

--- a/contracts/interfaces/IUnboundTokenSeller.sol
+++ b/contracts/interfaces/IUnboundTokenSeller.sol
@@ -19,7 +19,7 @@ interface IUnboundTokenSeller {
 
 /* ========== Mutative ========== */
 
-  function initialize(address pool, uint8 premiumPercent) external;
+  function initialize(address controller_, address pool, uint8 premiumPercent) external;
 
   function handleUnbindToken(address token, uint256 amount) external;
 

--- a/contracts/mocks/InitializerErrorTrigger.sol
+++ b/contracts/mocks/InitializerErrorTrigger.sol
@@ -18,7 +18,7 @@ contract InitializerErrorTrigger {
   address[] internal _tokens;
   uint256[] internal _balances;
 
-  function initialize(address pool, address[] calldata tokens, uint256[] calldata balances) external {
+  function initialize(address, address pool, address[] calldata tokens, uint256[] calldata balances) external {
     _tokens = tokens;
     _balances = balances;
     _pool = pool;

--- a/contracts/mocks/tests/SellerTest.sol
+++ b/contracts/mocks/tests/SellerTest.sol
@@ -37,12 +37,12 @@ contract SellerTest is TestTokenMarkets, Diff, TestOrder {
     TestTokenMarkets(_weth, _factory, _router)
   {
     oracle = _oracle;
-    seller = new UnboundTokenSeller(_router, _oracle, address(this));
+    seller = new UnboundTokenSeller(_router, _oracle);
     pool = new MockUnbindSourcePool(address(seller));
   }
 
   function test_initialize() external {
-    try seller.initialize(address(0), 2) {
+    try seller.initialize(address(this), address(0), 2) {
       revert("Error: Expected revert");
     } catch Error(string memory errorMsg) {
       require(
@@ -50,7 +50,7 @@ contract SellerTest is TestTokenMarkets, Diff, TestOrder {
         "Error: Expected ERR_NULL_ADDRESS error message."
       );
     }
-    try seller.initialize(address(pool), 0) {
+    try seller.initialize(address(this), address(pool), 0) {
       revert("Error: Expected revert");
     } catch Error(string memory errorMsg) {
       require(
@@ -58,7 +58,7 @@ contract SellerTest is TestTokenMarkets, Diff, TestOrder {
         "Error: Expected ERR_PREMIUM error message."
       );
     }
-    try seller.initialize(address(pool), 21) {
+    try seller.initialize(address(this), address(pool), 21) {
       revert("Error: Expected revert");
     } catch Error(string memory errorMsg) {
       require(
@@ -66,8 +66,8 @@ contract SellerTest is TestTokenMarkets, Diff, TestOrder {
         "Error: Expected ERR_PREMIUM error message."
       );
     }
-    seller.initialize(address(pool), 2);
-    try seller.initialize(address(pool), 2) {
+    seller.initialize(address(this), address(pool), 2);
+    try seller.initialize(address(this), address(pool), 2) {
       revert("Error: Expected revert");
     } catch Error(string memory errorMsg) {
       require(

--- a/test/PoolInitializer.spec.js
+++ b/test/PoolInitializer.spec.js
@@ -98,20 +98,17 @@ describe('PoolInitializer.sol', async () => {
   describe('initialize()', async () => {
     before(async () => {
       let PoolInitializer = await ethers.getContractFactory('PoolInitializer');
-      initializer = await PoolInitializer.deploy(zeroAddress, addresses[0]);
-    });
-
-    it('Reverts if not called by controller', async () => {
-      await verifyRejection(initializer.connect(signer2), 'initialize', /ERR_NOT_CONTROLLER/g, zeroAddress, [], []);
+      initializer = await PoolInitializer.deploy(zeroAddress);
     });
 
     it('Reverts if array lengths do not match', async () => {
-      await verifyRejection(initializer, 'initialize', /ERR_ARR_LEN/g, zeroAddress, [], [zero]);
+      await verifyRejection(initializer, 'initialize', /ERR_ARR_LEN/g, zeroAddress, zeroAddress, [], [zero]);
     });
 
     it('Succeeds with valid inputs on first call', async () => {
       const poolAddress = `0x${'ff'.repeat(20)}`;
       await initializer.initialize(
+        zeroAddress,
         poolAddress,
         [`0x${'aa'.repeat(20)}`, `0x${'bb'.repeat(20)}`],
         [toWei(2), toWei(2)]
@@ -119,7 +116,7 @@ describe('PoolInitializer.sol', async () => {
     });
 
     it('Reverts if already initialized', async () => {
-      await verifyRejection(initializer, 'initialize', /ERR_INITIALIZED/g, `0x${'ff'.repeat(20)}`, [], []);
+      await verifyRejection(initializer, 'initialize', /ERR_INITIALIZED/g, zeroAddress, `0x${'ff'.repeat(20)}`, [], []);
     });
   });
 

--- a/test/fixtures/controller.fixture.js
+++ b/test/fixtures/controller.fixture.js
@@ -56,7 +56,7 @@ const controllerFixture = async ({ deployments, getNamedAccounts, ethers }) => {
     { gasLimit: 400000 }
   ).then(r => r.wait());
 
-  const poolInitializerImplementation = await deploy('PoolInitializer', uniswapOracle.address, controller.address);
+  const poolInitializerImplementation = await deploy('PoolInitializer', uniswapOracle.address);
 
   await proxyManager.createManyToOneProxyRelationship(
     poolInitializerID,

--- a/test/fixtures/controller.fixture.js
+++ b/test/fixtures/controller.fixture.js
@@ -41,7 +41,7 @@ const controllerFixture = async ({ deployments, getNamedAccounts, ethers }) => {
   const controller = await ethers.getContractAt('MarketCapSqrtController', controllerAddress);
   await controller.initialize();
 
-  const tokenSellerImplementation = await deploy('UnboundTokenSeller', uniswapRouter.address, uniswapOracle.address, controller.address);
+  const tokenSellerImplementation = await deploy('UnboundTokenSeller', uniswapRouter.address, uniswapOracle.address);
   await proxyManager.createManyToOneProxyRelationship(
     sellerImplementationID,
     tokenSellerImplementation.address,


### PR DESCRIPTION
# UnboundTokenSeller.sol

Moved controller assignment from constructor to `initialize()`

# PoolInitializer.sol

Moved controller assignment from constructor to `initialize()`

# MarketCapSqrtController.sol

Updated calls to initialize functions on seller & initializer.

# test/

Updated tests and test fixtures to account for updates.