### PR TITLE
Add CommitteeProxy | Resolves #12

### DIFF
--- a/contracts/committee/CommitteeProxy.sol
+++ b/contracts/committee/CommitteeProxy.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+
+contract CommitteeProxy is Ownable {
+  event CommitteeChanged(address indexed previousCommittee, address indexed newCommittee);
+  event ExecuteTransaction(
+    address indexed target,
+    uint256 value,
+    string signature,
+    bytes data
+  );
+
+  address public committee;
+
+  constructor(address committee_) public Ownable() {
+    committee = committee_;
+    emit CommitteeChanged(address(0), committee_);
+  }
+
+  function setCommittee(address committee_) external onlyOwner {
+    emit CommitteeChanged(committee, committee_);
+    committee = committee_;
+  }
+
+  modifier onlyCommittee {
+    require(msg.sender == committee, "CommitteeProxy: caller is not the committee");
+    _;
+  }
+
+  function executeTransaction(
+    address target,
+    uint256 value,
+    string calldata signature,
+    bytes calldata data
+  )
+    external
+    payable
+    onlyCommittee
+    returns (bytes memory)
+  {
+    bytes memory callData;
+
+    if (bytes(signature).length == 0) {
+      callData = data;
+    } else {
+      callData = abi.encodePacked(bytes4(keccak256(bytes(signature))), data);
+    }
+    (bool success, bytes memory returnData) = target.call{value: value}(callData);
+
+    require(
+      success,
+      "CommitteeProxy::executeTransaction: Transaction execution reverted"
+    );
+    emit ExecuteTransaction(target, value, signature, data);
+    return returnData;
+  }
+}

--- a/test/CommitteeProxy.spec.js
+++ b/test/CommitteeProxy.spec.js
@@ -1,0 +1,103 @@
+const { defaultAbiCoder, keccak256 } = require("ethers/lib/utils");
+const { zeroAddress, toWei, verifyRejection, expect, expectEvent } = require("./utils");
+
+async function deploy(contractName, ...args) {
+  const Factory = await ethers.getContractFactory(contractName);
+  return Factory.deploy(...args);
+}
+
+describe('CommitteeProxy.sol', async () => {
+  let owner, committee, notOwner;
+  let proxy, token;
+
+  function setupTests() {
+    before(async () => {
+      (
+        [owner, committee, notOwner] = await ethers.getSigners()
+        .then(async (signers) => Promise.all(
+          signers.map(async (signer) => Object.assign(signer, { address: await signer.getAddress() })))
+        )
+      );
+      proxy = await deploy('CommitteeProxy', committee.address);
+      token = await deploy('MockERC20', 'Token', 'TKN');
+      await token.getFreeTokens(proxy.address, toWei(1000));
+    });
+  }
+
+  describe('Constructor & Settings', () => {
+    setupTests();
+
+    it('committee', async () => {
+      expect(await proxy.committee()).to.eq(committee.address);
+    })
+
+    it('owner', async () => {
+      expect(await proxy.owner()).to.eq(owner.address);
+    })
+  })
+
+  describe('setCommittee()', () => {
+    setupTests();
+
+    it('Reverts if not called by owner', async () => {
+      await verifyRejection(proxy.connect(notOwner), 'setCommittee', /Ownable: caller is not the owner/g, zeroAddress)
+    })
+
+    it('Sets the committee', async () => {
+      const tx = await proxy.setCommittee(notOwner.address);
+      expect(await proxy.committee()).to.eq(notOwner.address)
+      expectEvent(tx, 'CommitteeChanged')
+    })
+  })
+
+  describe('executeTransaction()', async () => {
+    setupTests();
+
+    it('Reverts if not called by committee', async () => {
+      await verifyRejection(
+        proxy,
+        'executeTransaction',
+        /CommitteeProxy: caller is not the committee/g,
+        zeroAddress,
+        0,
+        '',
+        '0x'
+      )
+    })
+
+    it('Executes transaction with function signature', async () => {
+      await proxy.connect(committee).executeTransaction(
+        token.address,
+        0,
+        'transfer(address,uint256)',
+        defaultAbiCoder.encode(['address', 'uint256'], [notOwner.address, toWei(500)])
+      );
+      expect((await token.balanceOf(notOwner.address)).eq(toWei(500))).to.be.true;
+    })
+
+    it('Executes transaction without function signature', async () => {
+      const fnSig = keccak256(Buffer.from('transfer(address,uint256)')).slice(0, 10);
+      const calldata = defaultAbiCoder.encode(['address', 'uint256'], [notOwner.address, toWei(500)]);
+      const data = fnSig.concat(calldata.slice(2))
+      await proxy.connect(committee).executeTransaction(
+        token.address,
+        0,
+        '',
+        data
+      );
+      expect((await token.balanceOf(notOwner.address)).eq(toWei(1000))).to.be.true;
+    })
+
+    it('Reverts if the call fails', async () => {
+      await verifyRejection(
+        proxy.connect(committee),
+        'executeTransaction',
+        /CommitteeProxy::executeTransaction: Transaction execution reverted/g,
+        token.address,
+        0,
+        'transfer(address,uint256)',
+        defaultAbiCoder.encode(['address', 'uint256'], [notOwner.address, toWei(500)])
+      )
+    })
+  })
+});


### PR DESCRIPTION
Added a CommitteeProxy contract which enables a DAO-assigned committee address to execute arbitrary transactions. Allow the DAO to re-assign the committee address.