### PR TITLE
Add pegged-weight scoring contract for a five-asset meta-index

### DIFF
--- a/contracts/scoring/ScoreByCMCPegged.sol
+++ b/contracts/scoring/ScoreByCMCPegged.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.6.0;
+
+/* ========== External Interfaces ========== */
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/* ========== External Libraries ========== */
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+/* ========== Internal Interfaces ========== */
+import "../interfaces/IScoringStrategy.sol";
+import "../interfaces/ICirculatingMarketCapOracle.sol";
+
+
+contract ScoreByCMCPegged is Ownable, IScoringStrategy {
+  using SafeMath for uint256;
+
+  // Chainlink or other circulating market cap oracle
+  address public circulatingMarketCapOracle;
+
+  constructor(address circulatingMarketCapOracle_) public Ownable() {
+    circulatingMarketCapOracle = circulatingMarketCapOracle_;
+  }
+
+  function getTokenScores(address[] calldata tokens)
+    external
+    view
+    override
+    returns (uint256[] memory scores)
+  {
+    require(tokens.length >= 4, "Not enough tokens");
+    uint256[] memory marketCaps = ICirculatingMarketCapOracle(circulatingMarketCapOracle).getCirculatingMarketCaps(tokens);
+    uint256[] memory positions = sortAndReturnPositions(marketCaps);
+    uint256 memory subscore = calculateIndexSum(marketCaps, positions);
+    uint256 len = positions.length;
+    scores = new uint256[](len);
+    scores[positions[0]] = peggedScore(subscore);
+    scores[positions[1]] = peggedScore(subScore);
+    for (uint i = 2; i < 5; i++) {
+      scores[positions[i]] = downscaledScore(marketCaps[positions[i]]);
+    }
+    for (uint256 j = 5; j < len; j++) {
+      scores[positions[j]] = 0;
+    }
+  }
+
+  /**
+   * @dev Sort a list of market caps and return an array with the index each
+   * sorted market cap occupied in the unsorted list.
+   *
+   * Example: [1, 2, 3] => [2, 1, 0]
+   *
+   * Note: This modifies the original list.
+   */
+  function sortAndReturnPositions(uint256[] memory marketCaps) internal pure returns(uint256[] memory positions) {
+    uint256 len = marketCaps.length;
+    positions = new uint256[](len);
+    for (uint256 i = 0; i < len; i++) positions[i] = i;
+    for (uint256 i = 0; i < len; i++) {
+      uint256 marketCap = marketCaps[i];
+      uint256 position = positions[i];
+      uint256 j = i - 1;
+      while (int(j) >= 0 && marketCaps[j] < marketCap) {
+        marketCaps[j + 1] = marketCaps[j];
+        positions[j+1] = positions[j];
+        j--;
+      }
+      marketCaps[j+1] = marketCap;
+      positions[j+1] = position;
+    }
+  }
+
+  /**
+   * @dev Update the address of the circulating market cap oracle.
+   */
+  function setCirculatingMarketCapOracle(address circulatingMarketCapOracle_) external onlyOwner {
+    circulatingMarketCapOracle = circulatingMarketCapOracle_;
+  }
+  
+  /**
+   * @dev Returns the sum of the third, fourth and fifth highest market caps.
+   * If WETH and WBTC are included, they're always going to be the top two, and we only want three others.
+   * Require statement unnecessary: already included in caller function getTokenScores
+   **/
+  function calculateIndexSum(uint256[] memory marketCaps, uint256 memory positions) internal pure returns(uint256 subtotal) {
+    uint256 subtotal = 0;
+    for (uint256 i = 2; i < 5; i++) {
+      subtotal += marketCaps[positions[i]];
+    }
+  }
+
+  /**
+   * @dev Given a sum score corresponding to the total CMC of the top three non-WETH/WBTC elements (the three other
+   * elements that we want to include), returns a value corresponding to 20% of said sum for pegged weights.
+   **/
+  function peggedScore(uint256 subscore) internal pure returns(uint256) {
+    return (subscore.mul(20)).div(100);
+  }
+  
+  /**
+   * @dev Given a circulating market cap retrieved via oracle (a component of the result of calculateIndexSum),
+   * scale the value down by 60% (the remnant after pegging WETH and WBTC to 20% each).
+   **/
+  function downscaledScore(uint256 oldScore) internal pure returns(uint256) {
+    return (oldScore.mul(60)).div(100);
+  }
+
+}

--- a/contracts/scoring/ScoreByCMCPegged20.sol
+++ b/contracts/scoring/ScoreByCMCPegged20.sol
@@ -12,7 +12,7 @@ import "../interfaces/IScoringStrategy.sol";
 import "../interfaces/ICirculatingMarketCapOracle.sol";
 
 
-contract ScoreByCMCPegged is Ownable, IScoringStrategy {
+contract ScoreByCMCPegged20 is Ownable, IScoringStrategy {
   using SafeMath for uint256;
 
   // Chainlink or other circulating market cap oracle
@@ -28,14 +28,14 @@ contract ScoreByCMCPegged is Ownable, IScoringStrategy {
     override
     returns (uint256[] memory scores)
   {
-    require(tokens.length >= 4, "Not enough tokens");
+    require(tokens.length >= 5, "Not enough tokens");
     uint256[] memory marketCaps = ICirculatingMarketCapOracle(circulatingMarketCapOracle).getCirculatingMarketCaps(tokens);
     uint256[] memory positions = sortAndReturnPositions(marketCaps);
-    uint256 memory subscore = calculateIndexSum(marketCaps, positions);
+    uint256 subscore = calculateIndexSum(marketCaps, positions);
     uint256 len = positions.length;
     scores = new uint256[](len);
     scores[positions[0]] = peggedScore(subscore);
-    scores[positions[1]] = peggedScore(subScore);
+    scores[positions[1]] = peggedScore(subscore);
     for (uint i = 2; i < 5; i++) {
       scores[positions[i]] = downscaledScore(marketCaps[positions[i]]);
     }
@@ -82,8 +82,7 @@ contract ScoreByCMCPegged is Ownable, IScoringStrategy {
    * If WETH and WBTC are included, they're always going to be the top two, and we only want three others.
    * Require statement unnecessary: already included in caller function getTokenScores
    **/
-  function calculateIndexSum(uint256[] memory marketCaps, uint256 memory positions) internal pure returns(uint256 subtotal) {
-    uint256 subtotal = 0;
+  function calculateIndexSum(uint256[] memory marketCaps, uint256[] memory positions) internal pure returns(uint256 subtotal) {
     for (uint256 i = 2; i < 5; i++) {
       subtotal += marketCaps[positions[i]];
     }

--- a/contracts/scoring/ScoreByCMCPegged20.sol
+++ b/contracts/scoring/ScoreByCMCPegged20.sol
@@ -37,7 +37,7 @@ contract ScoreByCMCPegged20 is Ownable, IScoringStrategy {
     scores[positions[0]] = peggedScore(subscore);
     scores[positions[1]] = peggedScore(subscore);
     for (uint i = 2; i < 5; i++) {
-      scores[positions[i]] = downscaledScore(marketCaps[positions[i]]);
+      scores[positions[i]] = downscaledScore(marketCaps[i]);
     }
     for (uint256 j = 5; j < len; j++) {
       scores[positions[j]] = 0;
@@ -93,7 +93,7 @@ contract ScoreByCMCPegged20 is Ownable, IScoringStrategy {
    * elements that we want to include), returns a value corresponding to 20% of said sum for pegged weights.
    **/
   function peggedScore(uint256 subscore) internal pure returns(uint256) {
-    return (subscore.mul(20)).div(100);
+    return (subscore.mul(20)).div(100e18);
   }
   
   /**
@@ -101,7 +101,7 @@ contract ScoreByCMCPegged20 is Ownable, IScoringStrategy {
    * scale the value down by 60% (the remnant after pegging WETH and WBTC to 20% each).
    **/
   function downscaledScore(uint256 oldScore) internal pure returns(uint256) {
-    return (oldScore.mul(60)).div(100);
+    return (oldScore.mul(60)).div(100e18);
   }
 
 }

--- a/test/scoring/ScoreByCMCPegged20.spec.js
+++ b/test/scoring/ScoreByCMCPegged20.spec.js
@@ -61,7 +61,7 @@ describe('ScoreByCMCPegged20.sol', () => {
         const token = `0x${(i + 1).toString(16).padStart(40, '0')}`;
         tokens.push(token);
         if (i < 2) {
-          caps.push(toWei(10000));
+          caps.push(toWei((100 / (i + 1)) * 100));
         } else {
           caps.push(toWei(i * 10));
         }

--- a/test/scoring/ScoreByCMCPegged20.spec.js
+++ b/test/scoring/ScoreByCMCPegged20.spec.js
@@ -54,16 +54,18 @@ describe('ScoreByCMCPegged20.sol', () => {
       );
     })
 
-    it('Returns scaled scores with pegged values for highest two CMCs as scores', async () => {
+    it('Returns scaled scores with pegged values for highest two CMCs', async () => {
       const tokens = [];
       const caps = [];
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < 7; i++) {
         const token = `0x${(i + 1).toString(16).padStart(40, '0')}`;
         tokens.push(token);
         if (i < 2) {
           caps.push(toWei((100 / (i + 1)) * 100));
-        } else {
+        } else if (i < 5) {
           caps.push(toWei(i * 10));
+        } else { 
+          caps.push(toWei(i)); 
         }
       }
       await circulatingMarketCapOracle.setCirculatingMarketCaps(tokens, caps);
@@ -73,6 +75,9 @@ describe('ScoreByCMCPegged20.sol', () => {
       expect(scores[2].eq(12)).to.be.true;
       expect(scores[3].eq(18)).to.be.true;
       expect(scores[4].eq(24)).to.be.true;
+      for (let j = 5; j < 7; j++) {
+        expect(scores[j].eq(0)).to.be.true;
+      }
     })
   })
 })

--- a/test/scoring/ScoreByCMCPegged20.spec.js
+++ b/test/scoring/ScoreByCMCPegged20.spec.js
@@ -1,0 +1,78 @@
+const { toWei, expect, verifyRejection, zeroAddress } = require("../utils");
+
+async function deploy(contractName, ...args) {
+  const Factory = await ethers.getContractFactory(contractName);
+  return Factory.deploy(...args);
+}
+
+describe('ScoreByCMCPegged20.sol', () => {
+  let circulatingMarketCapOracle, scoringStrategy;
+  let notOwner;
+
+  before(async () => {
+    ([, notOwner] = await ethers.getSigners()
+      .then(async (signers) => Promise.all(
+        signers.map(async (signer) => Object.assign(signer, { address: await signer.getAddress() })))
+    ));
+  })
+
+  function setupTests() {
+    before(async () => {
+      circulatingMarketCapOracle = await deploy('MockCirculatingCapOracle');
+      scoringStrategy = await deploy('ScoreByCMCPegged20', circulatingMarketCapOracle.address);
+      verifyRevert = (...args) => verifyRejection(scoringStrategy, ...args);
+    })
+  }
+
+  describe('setCirculatingMarketCapOracle()', () => {
+    setupTests();
+
+    it('Reverts if not called by owner', async () => {
+      await verifyRejection(
+        scoringStrategy.connect(notOwner),
+        'setCirculatingMarketCapOracle',
+        /Ownable: caller is not the owner/g,
+        zeroAddress
+      );
+    });
+
+    it('Sets new oracle', async () => {
+      await scoringStrategy.setCirculatingMarketCapOracle(zeroAddress);
+      expect(await scoringStrategy.circulatingMarketCapOracle()).to.eq(zeroAddress);
+    })
+  })
+
+  describe('getTokenScores()', () => {
+    setupTests();
+
+    it('Reverts if given less than 5 tokens', async () => {
+      await verifyRejection(
+        scoringStrategy,
+        'getTokenScores',
+        /Not enough tokens/g,
+        [zeroAddress, zeroAddress, zeroAddress, zeroAddress]
+      );
+    })
+
+    it('Returns scaled scores with pegged values for highest two CMCs as scores', async () => {
+      const tokens = [];
+      const caps = [];
+      for (let i = 0; i < 5; i++) {
+        const token = `0x${(i + 1).toString(16).padStart(40, '0')}`;
+        tokens.push(token);
+        if (i < 2) {
+          caps.push(toWei(10000));
+        } else {
+          caps.push(toWei(i * 10));
+        }
+      }
+      await circulatingMarketCapOracle.setCirculatingMarketCaps(tokens, caps);
+      const scores = await scoringStrategy.getTokenScores(tokens);
+      expect(scores[0].eq(18)).to.be.true;
+      expect(scores[1].eq(18)).to.be.true;
+      expect(scores[2].eq(12)).to.be.true;
+      expect(scores[3].eq(18)).to.be.true;
+      expect(scores[4].eq(24)).to.be.true;
+    })
+  })
+})


### PR DESCRIPTION
Top two assets pegged to 20% of final weighting.

## Justification.

If the tokens you pass in correspond to [DEGEN, WETH, CC10, DEFI5, WBTC], this contract will sum up the CMCs for the third-through-fifth highest (i.e. effectively excluding WETH and WBTC), then use the sum of these CMCs as the new basis from which to assign 20% weights to WETH and WBTC. The CMCs for the remaining assets are then scaled down by a factor of 0.6.

## Example

CMCs fetched by oracle (obvious toy numbers are obvious, since WETH and WBTC are going to blow everything else out of the water):

* WBTC = 100,000
* WETH = 50,000
* CC10 = 20
* DEGEN = 30
* DEFI5 = 40

Resulting score sum for 3-5th assets: 90 [20 + 30 + 40]

Downscaled scores:

* WBTC = 18 [90 * 0.2]
* WETH = 18 [ditto]
* CC10 = 12 [20 * 0.6]
* DEGEN = 18 [30 * 0.6]
* DEFI5 = 24 [40 * 0.6]

Sum of downscaled scores: 90.