### PR TITLE
Remove pool value estimation vulnerability

### DIFF
--- a/contracts/balancer/BConst.sol
+++ b/contracts/balancer/BConst.sol
@@ -20,6 +20,9 @@ contract BConst {
   // Minimum time passed between each weight update for a token.
   uint256 internal constant WEIGHT_UPDATE_DELAY = 30 minutes;
 
+  // Minimum time between each change to a token's minimum balance.
+  uint256 internal constant MIN_BAL_UPDATE_DELAY = 6 hours;
+
   // Maximum percent by which a weight can adjust at a time
   // relative to the current weight.
   // The number of iterations needed to move from weight A to weight B is the floor of:

--- a/contracts/balancer/SigmaIndexPoolV1.sol
+++ b/contracts/balancer/SigmaIndexPoolV1.sol
@@ -308,6 +308,7 @@ contract SigmaIndexPoolV1 is BToken, BMath, IIndexPool {
   )
     external
     override
+    _lock_
     _control_
   {
     Record storage record = _records[token];

--- a/contracts/balancer/SigmaIndexPoolV1.sol
+++ b/contracts/balancer/SigmaIndexPoolV1.sol
@@ -313,6 +313,8 @@ contract SigmaIndexPoolV1 is BToken, BMath, IIndexPool {
     Record storage record = _records[token];
     require(record.bound, "ERR_NOT_BOUND");
     require(!record.ready, "ERR_READY");
+    require(now - record.lastDenormUpdate >= MIN_BAL_UPDATE_DELAY, "MIN_BAL_UPDATE_DELAY");
+    record.lastDenormUpdate = uint40(now);
     _minimumBalances[token] = minimumBalance;
     emit LOG_MINIMUM_BALANCE_UPDATED(token, minimumBalance);
   }
@@ -1097,7 +1099,7 @@ contract SigmaIndexPoolV1 is BToken, BMath, IIndexPool {
     _records[token] = Record({
       bound: true,
       ready: false,
-      lastDenormUpdate: 0,
+      lastDenormUpdate: uint40(now),
       denorm: 0,
       desiredDenorm: desiredDenorm,
       index: uint8(_tokens.length),

--- a/contracts/balancer/SigmaIndexPoolV1.sol
+++ b/contracts/balancer/SigmaIndexPoolV1.sol
@@ -637,6 +637,7 @@ contract SigmaIndexPoolV1 is BToken, BMath, IIndexPool {
           uint256 additionalBalance = bsub(balance, minimumBalance);
           uint256 balRatio = bdiv(additionalBalance, minimumBalance);
           uint96 newDenorm = uint96(badd(MIN_WEIGHT, bmul(MIN_WEIGHT, balRatio)));
+          if (newDenorm > 2 * MIN_WEIGHT) newDenorm = uint96(2 * MIN_WEIGHT);
           record.denorm = newDenorm;
           record.lastDenormUpdate = uint40(now);
           _totalWeight = badd(_totalWeight, newDenorm);
@@ -1266,6 +1267,7 @@ contract SigmaIndexPoolV1 is BToken, BMath, IIndexPool {
         uint256 additionalBalance = bsub(realBalance, record.balance);
         uint256 balRatio = bdiv(additionalBalance, record.balance);
         record.denorm = uint96(badd(MIN_WEIGHT, bmul(MIN_WEIGHT, balRatio)));
+        if (record.denorm > 2 * MIN_WEIGHT) record.denorm = uint96(2 * MIN_WEIGHT);
         _records[token].denorm = record.denorm;
         _records[token].lastDenormUpdate = uint40(now);
         _totalWeight = badd(_totalWeight, record.denorm);

--- a/contracts/balancer/SigmaIndexPoolV1.sol
+++ b/contracts/balancer/SigmaIndexPoolV1.sol
@@ -943,40 +943,6 @@ contract SigmaIndexPoolV1 is BToken, BMath, IIndexPool {
   }
 
   /**
-   * @dev Finds the first token which is both initialized and has a
-   * desired weight above 0, then returns the address of that token
-   * and the extrapolated value of the pool in terms of that token.
-   *
-   * The value is extrapolated by multiplying the token's
-   * balance by the reciprocal of its normalized weight.
-   * @return (token, extrapolatedValue)
-   */
-  function extrapolatePoolValueFromToken()
-    external
-    view
-    override
-    _viewlock_
-    returns (address/* token */, uint256/* extrapolatedValue */)
-  {
-    address token;
-    uint256 extrapolatedValue;
-    uint256 len = _tokens.length;
-    for (uint256 i = 0; i < len; i++) {
-      token = _tokens[i];
-      Record storage record = _records[token];
-      if (record.ready && record.desiredDenorm > 0) {
-        extrapolatedValue = bmul(
-          record.balance,
-          bdiv(_totalWeight, record.denorm)
-        );
-        break;
-      }
-    }
-    require(extrapolatedValue > 0, "ERR_NONE_READY");
-    return (token, extrapolatedValue);
-  }
-
-  /**
    * @dev Get the total denormalized weight of the pool.
    */
   function getTotalDenormalizedWeight()

--- a/contracts/controller/SigmaControllerV1.sol
+++ b/contracts/controller/SigmaControllerV1.sol
@@ -628,9 +628,8 @@ contract SigmaControllerV1 is ScoredTokenLists, ControllerConstants {
 /* ==========  Internal Pool Utility Functions  ========== */
 
   /**
-   * @dev Estimate the total value of a pool by taking its first token's
-   * "virtual balance" (balance * (totalWeight/weight)) and multiplying
-   * by that token's average ether price from UniSwap.
+   * @dev Estimate the total value of a pool by taking the sum of
+   * TWAP values of the pool's balance in each token it has bound.
    */
   function _estimatePoolValue(address pool) internal view returns (uint256 totalValue) {
     address[] memory tokens = IIndexPool(pool).getCurrentTokens();

--- a/contracts/controller/SigmaControllerV1.sol
+++ b/contracts/controller/SigmaControllerV1.sol
@@ -4,6 +4,7 @@ pragma experimental ABIEncoderV2;
 
 /* ========== External Interfaces ========== */
 import "@indexed-finance/proxies/contracts/interfaces/IDelegateCallProxyManager.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /* ========== External Libraries ========== */
 import "@indexed-finance/proxies/contracts/SaltyLib.sol";
@@ -631,13 +632,18 @@ contract SigmaControllerV1 is ScoredTokenLists, ControllerConstants {
    * "virtual balance" (balance * (totalWeight/weight)) and multiplying
    * by that token's average ether price from UniSwap.
    */
-  function _estimatePoolValue(address pool) internal view returns (uint256) {
-    (address token, uint256 value) = IIndexPool(pool).extrapolatePoolValueFromToken();
-    return uniswapOracle.computeAverageEthForTokens(
-      token,
-      value,
+  function _estimatePoolValue(address pool) internal view returns (uint256 totalValue) {
+    address[] memory tokens = IIndexPool(pool).getCurrentTokens();
+    uint256 len = tokens.length;
+    uint256[] memory balances = new uint256[](len);
+    for (uint256 i; i < len; i++) balances[i] = IERC20(tokens[i]).balanceOf(address(pool));
+    uint256[] memory ethValues = uniswapOracle.computeAverageEthForTokens(
+      tokens,
+      balances,
       SHORT_TWAP_MIN_TIME_ELAPSED,
       SHORT_TWAP_MAX_TIME_ELAPSED
     );
+    // Safe math is not needed because we are taking the sum of an array of uint144s as a uint256.
+    for (uint256 i; i < len; i++) totalValue += ethValues[i];
   }
 }

--- a/contracts/interfaces/IIndexPool.sol
+++ b/contracts/interfaces/IIndexPool.sol
@@ -190,8 +190,6 @@ interface IIndexPool {
 
   function getTokenRecord(address token) external view returns (Record memory record);
 
-  function extrapolatePoolValueFromToken() external view returns (address/* token */, uint256/* extrapolatedValue */);
-
   function getTotalDenormalizedWeight() external view returns (uint256);
 
   function getBalance(address token) external view returns (uint256);

--- a/test/IPool/IPool.spec.js
+++ b/test/IPool/IPool.spec.js
@@ -219,7 +219,7 @@ describe('SigmaIndexPoolV1.sol', async () => {
     let from, pool, handler;
     let tokenA, tokenB, tokenC;
 
-    before(async () => {
+    beforeEach(async () => {
       ({ deployer: from } = await getNamedAccounts());
       const erc20Factory = await ethers.getContractFactory('MockERC20');
       tokenA = await erc20Factory.deploy('TokenA', 'A');
@@ -261,7 +261,7 @@ describe('SigmaIndexPoolV1.sol', async () => {
       const diff = balPost.sub(balPre);
       expect(diff.eq(toWei(1))).to.be.true;
     });
-
+  
     it('Updates balance for uninitialized tokens', async () => {
       await pool.reindexTokens(
         [tokenA.address, tokenC.address],
@@ -275,18 +275,56 @@ describe('SigmaIndexPoolV1.sol', async () => {
       expect(balPost.gt(balPre)).to.be.true;
       const diff = balPost.sub(balPre);
       expect(diff.eq(toWei(1))).to.be.true;
-
     });
-
-    it('Initializes token if minimumm balance is hit', async () => {
+  
+    it('Initializes token if minimum balance is hit', async () => {
+      await pool.reindexTokens(
+        [tokenA.address, tokenC.address],
+        [toWei(20), toWei(5)],
+        [0, toWei(10)]
+      );
       const denormPre = await pool.getDenormalizedWeight(tokenC.address);
       expect(denormPre.eq(0)).to.be.true;
-      await tokenC.getFreeTokens(pool.address, toWei(9));
+      await tokenC.getFreeTokens(pool.address, toWei(10));
       await pool.gulp(tokenC.address);
       const balPost = await pool.getBalance(tokenC.address);
       expect(balPost.eq(toWei(10))).to.be.true;
       const denormPost = await pool.getDenormalizedWeight(tokenC.address);
       const minWeight = toWei('0.25');
+      expect(denormPost.eq(minWeight)).to.be.true;
+    });
+  
+    it('Increases weight if minimum balance is exceeded', async () => {
+      await pool.reindexTokens(
+        [tokenA.address, tokenC.address],
+        [toWei(20), toWei(5)],
+        [0, toWei(10)]
+      );
+      const denormPre = await pool.getDenormalizedWeight(tokenC.address);
+      expect(denormPre.eq(0)).to.be.true;
+      await tokenC.getFreeTokens(pool.address, toWei(15));
+      await pool.gulp(tokenC.address);
+      const balPost = await pool.getBalance(tokenC.address);
+      expect(balPost.eq(toWei(15))).to.be.true;
+      const denormPost = await pool.getDenormalizedWeight(tokenC.address);
+      const minWeight = toWei('0.375');
+      expect(denormPost.eq(minWeight)).to.be.true;
+    });
+  
+    it('Caps weight on initialized token to 2%', async () => {
+      await pool.reindexTokens(
+        [tokenA.address, tokenC.address],
+        [toWei(20), toWei(5)],
+        [0, toWei(10)]
+      );
+      const denormPre = await pool.getDenormalizedWeight(tokenC.address);
+      expect(denormPre.eq(0)).to.be.true;
+      await tokenC.getFreeTokens(pool.address, toWei(25));
+      await pool.gulp(tokenC.address);
+      const balPost = await pool.getBalance(tokenC.address);
+      expect(balPost.eq(toWei(25))).to.be.true;
+      const denormPost = await pool.getDenormalizedWeight(tokenC.address);
+      const minWeight = toWei('0.5');
       expect(denormPost.eq(minWeight)).to.be.true;
     });
   });
@@ -597,6 +635,64 @@ describe('SigmaIndexPoolV1.sol', async () => {
       }
     });
 
+    it('Initializes token if minimum balance is reached', async () => {
+      await triggerReindex();
+      const tokenIn = newToken.address;
+      const tokenOut = tokens[0];
+      const tokenAmountIn = await indexPool.getMinimumBalance(tokenIn);
+      await mintAndApprove(tokenIn, tokenAmountIn);
+      await indexPool.swapExactAmountIn(
+        tokenIn,
+        tokenAmountIn.div(2),
+        tokenOut,
+        0,
+        maxPrice
+      );
+      await indexPool.swapExactAmountIn(
+        tokenIn,
+        tokenAmountIn.div(2),
+        tokenOut,
+        0,
+        maxPrice
+      );
+      const record = await indexPool.getTokenRecord(tokenIn);
+      expect(record.balance.eq(tokenAmountIn)).to.be.true;
+      expect(record.ready).to.be.true;
+      expect(record.denorm.eq(toWei(0.25))).to.be.true;
+    });
+
+    it('Initialized token weight exceeds min weight by proportion of min balance exceeded', async () => {
+      await triggerReindex();
+      const tokenIn = newToken.address;
+      const tokenOut = tokens[0];
+      const tokenAmountIn = await indexPool.getMinimumBalance(tokenIn);
+      await mintAndApprove(tokenIn, tokenAmountIn.mul(2));
+      await indexPool.swapExactAmountIn(
+        tokenIn,
+        tokenAmountIn.div(2).sub(1),
+        tokenOut,
+        0,
+        maxPrice
+      );
+      await indexPool.swapExactAmountIn(
+        tokenIn,
+        tokenAmountIn.div(2).sub(1),
+        tokenOut,
+        0,
+        maxPrice
+      );
+      await indexPool.swapExactAmountIn(
+        tokenIn,
+        tokenAmountIn.div(5).add(2),
+        tokenOut,
+        0,
+        maxPrice
+      );
+      const record = await indexPool.getTokenRecord(tokenIn);
+      expect(record.ready).to.be.true;
+      expect(record.denorm.eq(toWei(0.3))).to.be.true;
+    });
+
     it('Reverts if tokenOut is uninitialized', async () => {
       await triggerReindex();
       const tokenOut = newToken.address;
@@ -795,6 +891,19 @@ describe('SigmaIndexPoolV1.sol', async () => {
       expect(actualSupply.equals(expectedSupply)).to.be.true;
       ({tokens, balances, denormalizedWeights, normalizedWeights} = await getPoolData());
     });
+
+    it('Caps weight of initialized tokens at 2%', async () => {
+      await triggerReindex();
+      const poolAmountOut = (await indexPool.totalSupply()).mul(6);
+      const amountsIn = poolHelper.calcAllInGivenPoolOut(+fromWei(poolAmountOut), true);
+      for (let i = 0; i < poolHelper.tokens.length; i++) {
+        await mintAndApprove(poolHelper.tokens[i], toWei(amountsIn[i]).mul(2));
+      }
+      await indexPool.joinPool(poolAmountOut, [maxPrice, maxPrice, maxPrice, maxPrice, maxPrice]);
+      const record = await indexPool.getTokenRecord(newToken.address)
+      expect(record.ready).to.be.true;
+      expect(record.denorm.eq(toWei(0.5))).to.be.true;
+    })
   });
 
   describe('exitswapPoolAmountIn()', async () => {

--- a/test/IPool/IPool.spec.js
+++ b/test/IPool/IPool.spec.js
@@ -1,7 +1,7 @@
 const Decimal = require('decimal.js');
 const { calcRelativeDiff } = require('../lib/calc_comparisons');
 const { poolFixture } = require("../fixtures/pool.fixture");
-const { toWei, fromWei, zero, zeroAddress, expect, maxUint256: maxPrice, getTransactionTimestamp, verifyRejection, getFakerContract } = require('../utils');
+const { toWei, fromWei, zero, zeroAddress, expect, maxUint256: maxPrice, getTransactionTimestamp, verifyRejection, getFakerContract, fastForward } = require('../utils');
 const { BigNumber } = require('ethers');
 const { defaultAbiCoder } = require('ethers/lib/utils');
 
@@ -359,8 +359,13 @@ describe('SigmaIndexPoolV1.sol', async () => {
       await verifyRevert('setMinimumBalance', /ERR_READY/g, tokens[0], zero);
     });
 
-    it('Sets minimum balance of uninitialized token', async () => {
+    it('Reverts if MIN_BAL_UPDATE_DELAY has not elapsed since reindex', async () => {
       await triggerReindex();
+      await verifyRevert('setMinimumBalance', /MIN_BAL_UPDATE_DELAY/g, newToken.address, toWei(10));
+    })
+
+    it('Sets minimum balance of uninitialized token', async () => {
+      await fastForward(3600 * 7)
       await indexPool.setMinimumBalance(newToken.address, toWei(10));
       const minimumBalance = await indexPool.getMinimumBalance(newToken.address);
       expect(minimumBalance.eq(toWei(10))).to.be.true;
@@ -464,26 +469,6 @@ describe('SigmaIndexPoolV1.sol', async () => {
 
     it('Reverts if token is not bound', async () => {
       await verifyRevert('getTokenRecord', /ERR_NOT_BOUND/g, zeroAddress);
-    });
-  });
-
-  describe('extrapolatePoolValueFromToken()', async () => {
-    setupTests();
-
-    it('Succeeds if any token is ready and desired', async () => {
-      const [token, extrapolatedValue] = await indexPool.extrapolatePoolValueFromToken();
-      expect(token).to.eq(tokens[0]);
-      const total = await indexPool.getTotalDenormalizedWeight();
-      const expected = total.mul(balances[0]).div(denormalizedWeights[0]);
-      expect(+calcRelativeDiff(fromWei(expected), fromWei(extrapolatedValue))).to.be.lte(errorDelta);
-    });
-
-    it('Reverts if no tokens are both ready and desired', async () => {
-      await indexPool.reweighTokens(
-        tokens,
-        [zero, zero, zero]
-      );
-      await verifyRevert('extrapolatePoolValueFromToken', /ERR_NONE_READY/g);
     });
   });
 

--- a/test/IPool/Maximum.spec.js
+++ b/test/IPool/Maximum.spec.js
@@ -70,26 +70,6 @@ describe('SigmaIndexPoolV1.sol', async () => {
     await updateData();
   }
 
-  describe('extrapolatePoolValueFromToken()', async () => {
-    setupTests();
-
-    it('Succeeds if any token is ready and desired', async () => {
-      const [token, extrapolatedValue] = await indexPool.extrapolatePoolValueFromToken();
-      expect(token).to.eq(tokens[0]);
-      const total = await indexPool.getTotalDenormalizedWeight();
-      const expected = total.mul(balances[0]).div(denormalizedWeights[0]);
-      expect(+calcRelativeDiff(fromWei(expected), fromWei(extrapolatedValue))).to.be.lte(errorDelta);
-    });
-
-    it('Reverts if no tokens are both ready and desired', async () => {
-      await indexPool.reweighTokens(
-        tokens,
-        new Array(tokens.length).fill(0)
-      );
-      await verifyRevert('extrapolatePoolValueFromToken', /ERR_NONE_READY/g);
-    });
-  });
-
   describe('getSpotPrice()', async () => {
     setupTests();
 


### PR DESCRIPTION
# Remove pool value estimation vulnerability

This PR removes the vulnerability which was exploited in the recent attack, which was in the pool value estimation function in the controller. It also adds an additional safety measure in the minimum balance update function.

The primary change is to remove the `extrapolatePoolValueFromToken` function, which would return the address of the first token with a target weight over 0 and the value of the pool in terms of that token (estimated with `balance * totalDenorm / tokenDenorm`), and to modify the method in the controller used to estimate a pool's total value so that it takes the full value of the pool using a price oracle

## Changes to BConst.sol

Add a `MIN_BAL_UPDATE_DELAY` constant which is set to 6 hours. This value is the minimum period of time between changes to a token's minimum balance.

## Changes to SigmaIndexPoolV1.sol

Remove `extrapolatePoolValueFromToken`.

Modify `gulp` and `_updateInputToken` so that when a token exceeds its minimum balance, the weight is capped at `2 * MIN_WEIGHT`.

Modify `_bind` to set `lastDenormUpdate` for new tokens.

Modify `setMinimumBalance` to both update `lastDenormUpdate` and revert if less than `MIN_BAL_UPDATE_DELAY` has passed since the current `lastDenormUpdate`.

## Changes to SigmaControllerV1.sol

Modify `_estimatePoolValue` so that it will estimate the pool value using the full balance of all tokens in the pool.

